### PR TITLE
fix(compat): support future module relocation in nim devel

### DIFF
--- a/src/glob.nim
+++ b/src/glob.nim
@@ -139,7 +139,10 @@ will potentially be added in the future, for example:
 
 ]##
 
-import future
+when (NimMajor, NimMinor, NimPatch) >= (0, 18, 1):
+  from sugar import `=>`, `->`
+else:
+  import future
 import os
 import strutils
 from sequtils import toSeq

--- a/src/glob.nim
+++ b/src/glob.nim
@@ -142,7 +142,7 @@ will potentially be added in the future, for example:
 when (NimMajor, NimMinor, NimPatch) >= (0, 18, 1):
   from sugar import `=>`, `->`
 else:
-  import future
+  from future import `=>`, `->`
 import os
 import strutils
 from sequtils import toSeq

--- a/tests.nim
+++ b/tests.nim
@@ -1,7 +1,7 @@
 when (NimMajor, NimMinor, NimPatch) >= (0, 18, 1):
   from sugar import `=>`, `->`
 else:
-  import future
+  from future import `=>`, `->`
 import ospaths
 from os import createDir, removeDir, getCurrentDir
 from algorithm import sortedByIt

--- a/tests.nim
+++ b/tests.nim
@@ -1,4 +1,7 @@
-import future
+when (NimMajor, NimMinor, NimPatch) >= (0, 18, 1):
+  from sugar import `=>`, `->`
+else:
+  import future
 import ospaths
 from os import createDir, removeDir, getCurrentDir
 from algorithm import sortedByIt


### PR DESCRIPTION
The next release of nim will see `future` moving to `sugar`.  Currently a deprecation warning appears while using this `glob` on `devel`, and well, I won't be able to sleep that well if I don't PR this.

Thanks for writing this library. :tada: 
