### PR TITLE
fix(walk): match filesystem casing for entries on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os:
+  - linux
+  - osx
+
 language: c
 
 env:


### PR DESCRIPTION
Closes #32 

We now use a call to [`expandFilename`](https://nim-lang.org/docs/os.html#expandFilename,string) to get the path's casing as it exists in the filesystem. This has refactored things a bit so that instead of tracking relative paths and converting them to absolutes, we use absolutes and convert them relatives.

This PR also introduces macOS testing on travis against both stable & devel versions of nim just like the linux tests. Stable Nim (< 0.19.0) on macOS will currently fail &mdash; this is because [`FileSystemCaseSensitive`](https://nim-lang.org/docs/ospaths.html#FileSystemCaseSensitive) returned `true` for macOS until https://github.com/nim-lang/Nim/pull/8411 which is in Nim >= 0.19.0 (currently devel but soon to be stable). 

All this means for users is that the casing of returned filesystem entries doesn't quite match the actual filesystem &mdash; the results are otherwise correct, so I don't consider this much of a showstopper.