### PR TITLE
fix #35 ; simplify code a bit

### DIFF
--- a/src/glob.nim
+++ b/src/glob.nim
@@ -369,6 +369,7 @@ func splitPattern* (pattern: string): PatternStems =
 
 func glob* (pattern: string, isDos = isDosDefault, ignoreCase = isDosDefault): Glob =
   ## Constructs a new `Glob <#Glob>`_ object from the given ``pattern``.
+  let pattern = pattern.normalizedPath
   let rgx = globToRegexString(pattern, isDos, ignoreCase)
   let (base, magic) = pattern.splitPattern
   result = Glob(
@@ -382,15 +383,17 @@ func glob* (pattern: string, isDos = isDosDefault, ignoreCase = isDosDefault): G
 func matches* (input: string, glob: Glob): bool =
   ## Returns ``true`` if ``input`` is a match for the given ``glob`` object.
   runnableExamples:
+    const matcher = glob("src/**/*.nim")
+    const matcher2 = glob("bar//src//**/*.nim")
     when defined posix:
-      const matcher = glob("src/**/*.nim")
       doAssert("src/dir/foo.nim".matches(matcher))
       doAssert(not r"src\dir\foo.nim".matches(matcher))
+      doAssert("bar/src/dir/foo.nim".matches(matcher2))
+      doAssert("./bar//src/baz.nim".matches(matcher2))
     elif defined windows:
-      const matcher = glob("src/**/*.nim")
       doAssert(r"src\dir\foo.nim".matches(matcher))
       doAssert(not "src/dir/foo.nim".matches(matcher))
-
+  let input = input.normalizedPath
   input.contains(glob.regex)
 
 func matches* (input, pattern: string; isDos = isDosDefault, ignoreCase = isDosDefault): bool =
@@ -465,11 +468,14 @@ iterator walkGlobKinds* (
     for path, kind in walkGlobKinds("src/**/*", options = optsHiddenNoLinks):
       doAssert(kind notin {pcLinkToFile, pcLinkToDir})
 
+  when pattern is string:
+    let pattern = pattern.glob
+
   let internalRoot =
     if root == "": getCurrentDir()
     elif root.isAbsolute: root
     else: getCurrentDir() / root
-  var matchPattern = when pattern is Glob: pattern.pattern else: pattern
+  var matchPattern = pattern.pattern
   var proceed = matchPattern.hasMagic
 
   template push (path: string, kind: PathComponent, dir = "") =
@@ -499,14 +505,8 @@ iterator walkGlobKinds* (
         if FileLinks in options: push(path, kind, internalRoot)
 
   if proceed:
-    var dir: string
-    when pattern is Glob:
-      dir = maybeJoin(internalRoot, pattern.base)
-      matchPattern = pattern.magic.expandGlob(dir, IgnoreCase in options)
-    else:
-      let stems = splitPattern(matchPattern)
-      dir = maybeJoin(internalRoot, stems.base)
-      matchPattern = stems.magic
+    let dir = maybeJoin(internalRoot, pattern.base)
+    matchPattern = pattern.magic.expandGlob(dir, IgnoreCase in options)
 
     let matcher = matchPattern.globToRegex(ignoreCase = IgnoreCase in options)
     let isRec = "**" in matchPattern
@@ -586,6 +586,9 @@ iterator walkGlob* (
       ## `path` is a file in the `docs` directory or any of its
       ## subdirectories with either a `png` or `svg` file extension
       discard
+
+  when pattern is string:
+    let pattern = pattern.glob
 
   for path, _ in walkGlobKinds(pattern, root, options, filterDescend, filterYield):
     yield path


### PR DESCRIPTION
* fix #35
/cc @citycide 

I've simplified code a bit by adding this:
```nim
 when pattern is string:
    let pattern = pattern.glob
```
so that the remaining code only has to deal with Glob, not string; my understanding is this should have no performance impact in the sense I doubt the code would be more efficient when using a simple string pattern as opposed to a Glob object (eg because file operations should be more expensive anyways); but let me know if you disagree