### PR TITLE
fix: normalize input paths on posix; simplify code a bit

### DIFF
--- a/src/glob.nim
+++ b/src/glob.nim
@@ -369,7 +369,9 @@ func splitPattern* (pattern: string): PatternStems =
 
 func glob* (pattern: string, isDos = isDosDefault, ignoreCase = isDosDefault): Glob =
   ## Constructs a new `Glob <#Glob>`_ object from the given ``pattern``.
-  let pattern = pattern.normalizedPath
+  when defined(posix):
+    # causes complications on windows since that would change / to \
+    let pattern = pattern.normalizedPath
   let rgx = globToRegexString(pattern, isDos, ignoreCase)
   let (base, magic) = pattern.splitPattern
   result = Glob(
@@ -393,7 +395,9 @@ func matches* (input: string, glob: Glob): bool =
     elif defined windows:
       doAssert(r"src\dir\foo.nim".matches(matcher))
       doAssert(not "src/dir/foo.nim".matches(matcher))
-  let input = input.normalizedPath
+  when defined(posix):
+    # see note in `glob`
+    let input = input.normalizedPath
   input.contains(glob.regex)
 
 func matches* (input, pattern: string; isDos = isDosDefault, ignoreCase = isDosDefault): bool =

--- a/src/glob.nim
+++ b/src/glob.nim
@@ -369,6 +369,7 @@ func splitPattern* (pattern: string): PatternStems =
 
 func glob* (pattern: string, isDos = isDosDefault, ignoreCase = isDosDefault): Glob =
   ## Constructs a new `Glob <#Glob>`_ object from the given ``pattern``.
+  let pattern = pattern.normalizedPath
   let rgx = globToRegexString(pattern, isDos, ignoreCase)
   let (base, magic) = pattern.splitPattern
   result = Glob(
@@ -382,15 +383,17 @@ func glob* (pattern: string, isDos = isDosDefault, ignoreCase = isDosDefault): G
 func matches* (input: string, glob: Glob): bool =
   ## Returns ``true`` if ``input`` is a match for the given ``glob`` object.
   runnableExamples:
+    const matcher = glob("src/**/*.nim")
+    const matcher2 = glob("bar//src//**/*.nim")
     when defined posix:
-      const matcher = glob("src/**/*.nim")
       doAssert("src/dir/foo.nim".matches(matcher))
       doAssert(not r"src\dir\foo.nim".matches(matcher))
+      doAssert("bar/src/dir/foo.nim".matches(matcher2))
+      doAssert("./bar//src/baz.nim".matches(matcher2))
     elif defined windows:
-      const matcher = glob("src/**/*.nim")
       doAssert(r"src\dir\foo.nim".matches(matcher))
       doAssert(not "src/dir/foo.nim".matches(matcher))
-
+  let input = input.normalizedPath
   input.contains(glob.regex)
 
 func matches* (input, pattern: string; isDos = isDosDefault, ignoreCase = isDosDefault): bool =
@@ -465,11 +468,14 @@ iterator walkGlobKinds* (
     for path, kind in walkGlobKinds("src/**/*", options = optsHiddenNoLinks):
       doAssert(kind notin {pcLinkToFile, pcLinkToDir})
 
+  when pattern is string:
+    let pattern = pattern.glob
+
   let internalRoot =
     if root == "": getCurrentDir()
     elif root.isAbsolute: root
     else: getCurrentDir() / root
-  var matchPattern = when pattern is Glob: pattern.pattern else: pattern
+  var matchPattern = pattern.pattern
   var proceed = matchPattern.hasMagic
 
   template push (path: string, kind: PathComponent, dir = "") =
@@ -499,14 +505,8 @@ iterator walkGlobKinds* (
         if FileLinks in options: push(path, kind, internalRoot)
 
   if proceed:
-    var dir: string
-    when pattern is Glob:
-      dir = maybeJoin(internalRoot, pattern.base)
-      matchPattern = pattern.magic.expandGlob(dir, IgnoreCase in options)
-    else:
-      let stems = splitPattern(matchPattern)
-      dir = maybeJoin(internalRoot, stems.base)
-      matchPattern = stems.magic
+    let dir = maybeJoin(internalRoot, pattern.base)
+    matchPattern = pattern.magic.expandGlob(dir, IgnoreCase in options)
 
     let matcher = matchPattern.globToRegex(ignoreCase = IgnoreCase in options)
     let isRec = "**" in matchPattern
@@ -586,6 +586,9 @@ iterator walkGlob* (
       ## `path` is a file in the `docs` directory or any of its
       ## subdirectories with either a `png` or `svg` file extension
       discard
+
+  when pattern is string:
+    let pattern = pattern.glob
 
   for path, _ in walkGlobKinds(pattern, root, options, filterDescend, filterYield):
     yield path


### PR DESCRIPTION
/cc @citycide 
reattempts https://github.com/citycide/glob/pull/37 which had been reverted because it was causing issues on windows (due to lack of windows being tested back then)

## note
I'm now only doing normalizedPath on posix, because it would cause complications on windows as it changes `/` to `\`
if someone needs a fix for #35 on windows, it can be handled in subsequent PR's; but right now the test suite is a bit weird for reasons unrelated to this PR: see https://github.com/citycide/glob/issues/46

## note2:
pathnorm.normalizePath might help with that but I don't want it in same PR, eg see `proc normalizePath*(path: string; dirSep = DirSep): string =`
