### PR TITLE
Require regex < 0.17

### DIFF
--- a/glob.nimble
+++ b/glob.nimble
@@ -7,7 +7,7 @@ skipDirs      = @["docsrc"]
 skipFiles     = @["tests.nim"]
 
 requires "nim >= 0.18.0"
-requires "regex >= 0.7.4"
+requires "regex >= 0.16.0 & < 0.17.0"
 
 task test, "Run the test suite":
   exec "nimble c -y --hints:off --verbosity:0 -r tests.nim"


### PR DESCRIPTION
Closes #49 

Version 0.17.0 introduces an as of yet unidentified breakage.