### PR TITLE
refactor: allow nim 2.0

### DIFF
--- a/glob.nimble
+++ b/glob.nimble
@@ -6,7 +6,7 @@ srcDir        = "src"
 skipDirs      = @["docsrc"]
 skipFiles     = @["tests.nim"]
 
-requires "nim >= 1.0.0 & < 2.0.0"
+requires "nim >= 1.0.0"
 requires "regex >= 0.20.0"
 
 task test, "Run the test suite":


### PR DESCRIPTION
This was [originally added](https://github.com/haltcase/glob/commit/66ef3b353c1be5255557e7113d6b6e5b242ae2f0) to require Nim be above version 1.0. However there is also a `< 2.0.0` constraint, which breaks nim CI if the nim's version is updated to 2.0 (see https://github.com/nim-lang/Nim/pull/20968), despite this package working for the development version of 2.0 for a while.